### PR TITLE
 #156008359 Share functionality for Github users profile 

### DIFF
--- a/app/src/main/java/com/andela/javadevsnairobi/views/DevDetailActivity.java
+++ b/app/src/main/java/com/andela/javadevsnairobi/views/DevDetailActivity.java
@@ -1,8 +1,13 @@
 package com.andela.javadevsnairobi.views;
 
+import android.content.Intent;
+import android.support.constraint.ConstraintLayout;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -13,14 +18,16 @@ import com.squareup.picasso.Picasso;
 
 import jp.wasabeef.picasso.transformations.CropCircleTransformation;
 
-public class DevDetailActivity extends AppCompatActivity implements GithubUserView {
+public class DevDetailActivity extends AppCompatActivity implements GithubUserView, View.OnClickListener {
 
     TextView username;
     TextView name;
     TextView githubUrl;
     TextView bio;
     ImageView avatar;
+    Button shareButton;
     GithubPresenter presenter;
+    ConstraintLayout profileView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -33,6 +40,10 @@ public class DevDetailActivity extends AppCompatActivity implements GithubUserVi
         githubUrl = findViewById(R.id.dev_github_link);
         bio = findViewById(R.id.dev_bio);
         avatar = findViewById(R.id.dev_avatar);
+        profileView = findViewById(R.id.rectangle);
+
+        shareButton = findViewById(R.id.dev_share_btn);
+        shareButton.setOnClickListener(this);
 
         presenter = new GithubPresenter(this);
         String username = getIntent().getExtras().getString("username");
@@ -59,5 +70,28 @@ public class DevDetailActivity extends AppCompatActivity implements GithubUserVi
         githubUrl.setText(githubUser.getHtmlUrl());
         Picasso.get().load(githubUser.getAvatarUrl())
                 .transform(new CropCircleTransformation()).into(avatar);
+        if (githubUser.getBio() != null)
+            if (githubUser.getBio().contains("\n"))
+                resizeProfileViewHeight(profileView, githubUser.getBio());
+    }
+
+    @Override
+    public void onClick(View v) {
+        String user_name = (String) username.getText();
+        String url = (String) githubUrl.getText();
+        String message = String.format("Checkout this awesome developer @%s, %s", user_name, url);
+
+        Intent shareIntent = new Intent(Intent.ACTION_SEND);
+        shareIntent.setType("text/plain");
+        shareIntent.putExtra(Intent.EXTRA_TEXT, message);
+        startActivity(Intent.createChooser(shareIntent, "Share using "));
+    }
+
+    public void resizeProfileViewHeight(ConstraintLayout profileView, String bio) {
+        int lines = bio.split("\n").length;
+        int extraHeight = lines * 15;
+        ViewGroup.LayoutParams params = profileView.getLayoutParams();
+        params.height += extraHeight;
+        profileView.setLayoutParams(params);
     }
 }

--- a/app/src/main/res/layout/dev_detail.xml
+++ b/app/src/main/res/layout/dev_detail.xml
@@ -27,7 +27,6 @@
             app:layout_constraintRight_toRightOf="@id/rectangle"
             app:layout_constraintBottom_toTopOf="@id/dev_bio"
             android:id="@+id/dev_name"
-            android:text="@string/dev_full_name"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 
@@ -38,7 +37,6 @@
             app:layout_constraintRight_toRightOf="@id/rectangle"
             app:layout_constraintBottom_toTopOf="@id/dev_github_link"
             android:id="@+id/dev_bio"
-            android:text="@string/dev_bio"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 
@@ -49,7 +47,6 @@
             android:drawablePadding="@dimen/small_margin"
             app:layout_constraintBottom_toTopOf="@+id/dev_username"
             android:id="@+id/dev_github_link"
-            android:text="@string/dev_username"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:drawableLeft="@drawable/ic_link_grey_24dp" />
@@ -61,7 +58,6 @@
             android:drawablePadding="@dimen/small_margin"
             app:layout_constraintBottom_toBottomOf="@id/rectangle"
             android:id="@+id/dev_username"
-            android:text="@string/dev_github_link"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:drawableLeft="@drawable/ic_account_circle_grey_24dp" />
@@ -96,6 +92,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         android:padding="@dimen/small_margin"
         android:drawablePadding="@dimen/small_margin"
+        android:id="@+id/dev_share_btn"
         android:text="@string/share_profile"
         android:drawableStart="@drawable/ic_share_white_24dp"
         android:textColor="@color/colorWhite"

--- a/app/src/main/res/layout/devs_list_item.xml
+++ b/app/src/main/res/layout/devs_list_item.xml
@@ -19,7 +19,6 @@
     </RelativeLayout>
 
      <TextView
-        android:text="@string/dev_username"
         style="@style/Base.TextAppearance.AppCompat.Body1"
         android:id="@+id/dev_list_username"
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,8 +1,4 @@
 <resources>
     <string name="app_name">Java Devs Nairobi</string>
-    <string name="dev_username">GithubUser</string>
-    <string name="dev_full_name">Github User</string>
-    <string name="dev_bio">GithubUser is super cool. the coolest you will ever know.</string>
-    <string name="dev_github_link">https://github.com/githubuser</string>
     <string name="share_profile">Share profile</string>
 </resources>


### PR DESCRIPTION
#### What does this PR do?
- It introduces sharing functionality for github profiles.

#### Description of Task to be completed?
- Add a button click listener
- Create a share intent
- Start activity with the intent chooser

#### How should this be manually tested?
- Fetch and checkout into this branch `ft-share-functionality-156008359`
- Run Gradle sync to resolve dependencies
- Run the App in the emulator.
- Navigate to the single developer profile and click the *Share Profile* button.

#### What are the relevant pivotal tracker stories?
 [#156008359](https://www.pivotaltracker.com/story/show/156008359)

#### Screenshots
![github_share](https://user-images.githubusercontent.com/17139402/55147540-a1cbbf80-5157-11e9-82b1-4b48d07de7d5.gif)

