### PR TITLE
#156005187 handling configuration changes

### DIFF
--- a/app/src/main/java/com/andela/javadevsnairobi/views/DevDetailActivity.java
+++ b/app/src/main/java/com/andela/javadevsnairobi/views/DevDetailActivity.java
@@ -1,6 +1,7 @@
 package com.andela.javadevsnairobi.views;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.support.constraint.ConstraintLayout;
 import android.app.ProgressDialog;
 import android.support.v7.app.AppCompatActivity;
@@ -15,6 +16,7 @@ import android.widget.TextView;
 import com.andela.javadevsnairobi.R;
 import com.andela.javadevsnairobi.model.GithubUser;
 import com.andela.javadevsnairobi.presenter.GithubPresenter;
+import com.google.gson.Gson;
 import com.squareup.picasso.Picasso;
 
 import jp.wasabeef.picasso.transformations.CropCircleTransformation;
@@ -30,6 +32,7 @@ public class DevDetailActivity extends AppCompatActivity implements GithubUserVi
     GithubPresenter presenter;
     ConstraintLayout profileView;
     ProgressDialog progressDialog;
+    GithubUser mGithubUser;
 
 
     @Override
@@ -58,6 +61,7 @@ public class DevDetailActivity extends AppCompatActivity implements GithubUserVi
 
     }
 
+
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
@@ -71,6 +75,7 @@ public class DevDetailActivity extends AppCompatActivity implements GithubUserVi
 
     @Override
     public void showUser(GithubUser githubUser) {
+        mGithubUser = githubUser;
         username.setText(githubUser.getUsername());
         name.setText(githubUser.getName());
         bio.setText(githubUser.getBio());
@@ -95,6 +100,26 @@ public class DevDetailActivity extends AppCompatActivity implements GithubUserVi
         startActivity(Intent.createChooser(shareIntent, "Share using "));
     }
 
+    @Override
+    protected void onPause() {
+        super.onPause();
+        String serailizedGithubUser = new Gson().toJson(mGithubUser);
+        SharedPreferences githubUser = getSharedPreferences("GithubUser", MODE_PRIVATE);
+        SharedPreferences.Editor editor = githubUser.edit();
+        editor.putString("githubUser", serailizedGithubUser);
+        editor.apply();
+
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        SharedPreferences githubUser = getSharedPreferences("GithubUser", MODE_PRIVATE);
+        String serializedGithubUser = githubUser.getString("githubUser", null);
+        GithubUser mGithubUser = new Gson().fromJson(serializedGithubUser, GithubUser.class);
+        if (mGithubUser != null) showUser(mGithubUser);
+    }
+
     public void resizeProfileViewHeight(ConstraintLayout profileView, String bio) {
         int lines = bio.split("\n").length;
         int extraHeight = lines * 15;
@@ -103,4 +128,5 @@ public class DevDetailActivity extends AppCompatActivity implements GithubUserVi
         profileView.setLayoutParams(params);
         progressDialog.hide();
     }
+
 }

--- a/app/src/main/java/com/andela/javadevsnairobi/views/MainActivity.java
+++ b/app/src/main/java/com/andela/javadevsnairobi/views/MainActivity.java
@@ -1,6 +1,7 @@
 package com.andela.javadevsnairobi.views;
 
 import android.app.ProgressDialog;
+import android.content.SharedPreferences;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
@@ -16,7 +17,10 @@ import com.andela.javadevsnairobi.R;
 import com.andela.javadevsnairobi.adapter.GithubAdapter;
 import com.andela.javadevsnairobi.model.GithubUser;
 import com.andela.javadevsnairobi.presenter.GithubPresenter;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 
+import java.lang.reflect.Type;
 import java.util.List;
 
 public class MainActivity extends AppCompatActivity implements GithubAllUsersView {
@@ -25,6 +29,7 @@ public class MainActivity extends AppCompatActivity implements GithubAllUsersVie
     GithubPresenter presenter;
     SwipeRefreshLayout swipeRefreshLayout;
     ProgressDialog progressDialog;
+    List<GithubUser> mGithubUsers;
 
 
     @Override
@@ -33,7 +38,7 @@ public class MainActivity extends AppCompatActivity implements GithubAllUsersVie
         setContentView(R.layout.activity_main);
 
         devsRecyclerView = findViewById(R.id.devs_recycler_view);
-        devsRecyclerView.setLayoutManager(new GridLayoutManager(this,getResources().getInteger(R.integer.column_count)));
+        devsRecyclerView.setLayoutManager(new GridLayoutManager(this, getResources().getInteger(R.integer.column_count)));
         presenter = new GithubPresenter(this);
         presenter.getAllUsers();
 
@@ -52,6 +57,7 @@ public class MainActivity extends AppCompatActivity implements GithubAllUsersVie
 
     @Override
     public void showAllUsers(List<GithubUser> githubUsers) {
+        mGithubUsers = githubUsers;
         GithubAdapter adapter = new GithubAdapter(githubUsers);
         devsRecyclerView.setAdapter(adapter);
         swipeRefreshLayout.setRefreshing(false);
@@ -61,19 +67,42 @@ public class MainActivity extends AppCompatActivity implements GithubAllUsersVie
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         MenuInflater inflater = getMenuInflater();
-        inflater.inflate(R.menu.main_menu,menu);
+        inflater.inflate(R.menu.main_menu, menu);
         return true;
     }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
 
-        switch (item.getItemId()){
+        switch (item.getItemId()) {
             case R.id.refresh_item:
                 swipeRefreshLayout.setRefreshing(true);
                 presenter.getAllUsers();
                 return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        Type listType = new TypeToken<List<GithubUser>>() {
+        }.getType();
+        String serailizedGithubUsers = new Gson().toJson(mGithubUsers, listType);
+        SharedPreferences githubUsers = getSharedPreferences("GithubUsers", MODE_PRIVATE);
+        SharedPreferences.Editor editor = githubUsers.edit();
+        editor.putString("github users", serailizedGithubUsers);
+        editor.apply();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        Type listType = new TypeToken<List<GithubUser>>() {
+        }.getType();
+        SharedPreferences githubUsers = getSharedPreferences("GithubUsers", MODE_PRIVATE);
+        String serializedGithubUsers = githubUsers.getString("github users", null);
+        List<GithubUser> githubUserList = new Gson().fromJson(serializedGithubUsers, listType);
+        if (githubUserList != null) showAllUsers(githubUserList);
     }
 }


### PR DESCRIPTION
#### What does this PR do?
- It prevents the app from reloading data when the device's configuration changes.

#### Description of Task to be completed?
- override onPause and onResume methods
- Serialize the GitHub user and GitHub users list objects
- save them in shared preferences.

#### How should this be manually tested?
- Fetch and checkout into this branch `ft-config-changes-156005187`
- Run Gradle sync to resolve dependencies
- Run the App in the emulator.
- change the screen's orientation
- The app shall not fetch remote data.

#### What are the relevant pivotal tracker stories?
 [#156005187](https://www.pivotaltracker.com/story/show/156005187)

#### Screenshots
Before:
![config_change_before](https://user-images.githubusercontent.com/17139402/55543257-625e1f80-56d1-11e9-95d8-002cb7fa0918.gif)

After:
![config_change_after](https://user-images.githubusercontent.com/17139402/55543261-64c07980-56d1-11e9-8e66-8a4360b27062.gif)
